### PR TITLE
Add handling for user edited config.toml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ EXPOSE 54321
 COPY run-dai-nimbix.sh /run-dai-nimbix.sh
 
 # Nimbix Integrations
+COPY NAE/url.txt /etc/NAE/url.txt
+COPY NAE/help.html /etc/NAE/help.html
 COPY NAE/AppDef.json /etc/NAE/AppDef.json
 COPY NAE/AppDef.png /etc//NAE/default.png
 COPY NAE/screenshot.png /etc/NAE/screenshot.png

--- a/NAE/AppDef.json
+++ b/NAE/AppDef.json
@@ -19,19 +19,69 @@
         "OBJECT"
     ],
     "commands": {
-      "DAI": {
+        "DAI": {
             "path": "/run-dai-nimbix.sh",
             "interactive": true,
             "name": "DAI Server",
             "description": "Run the DAI Server",
-            "parameters": {}
+            "parameters": {
+                "-l": {
+                    "name": "-l",
+                    "description": "-l",
+                    "type": "CONST",
+                    "value": "-l",
+                    "positional": true,
+                    "required": true
+                },
+                "-c": {
+                    "name": "-c",
+                    "description": "-c",
+                    "type": "CONST",
+                    "value": "-c",
+                    "positional": true,
+                    "required": true
+                },
+                "command": {
+                    "name": "Command",
+                    "description": "command to launch DAI Server",
+                    "type": "CONST",
+                    "value": "/run-dai-nimbix.sh",
+                    "positional": true,
+                    "required": true
+                },
+                "gpus": {
+                    "name": "num_gpus",
+                    "description": "number of GPUs available to the machine",
+                    "type": "CONST",
+                    "value": "%TGPUS%",
+                    "positional": true,
+                    "required": true
+                },
+                "config": {
+                    "name": "Config File",
+                    "description": "Configuration File for Driverless AI",
+                    "type": "FILE",
+                    "filter": "*.toml",
+                    "positional": true,
+                    "required": false
+                }
+            }
         },
-      "SSH": {
-           "path": "/sbin/init",
-           "interactive": true,
-           "name": "SSH",
-           "description": "Launch a session with a SSH server, Connection address and credentials will appear in your web browser once available.",
-           "parameters": {}
+        "SSH": {
+            "path": "/sbin/init",
+            "interactive": true,
+            "name": "SSH",
+            "description": "Launch a session with a SSH server, Connection address and credentials will appear in your web browser once available.",
+            "parameters": {
+                "config": {
+                    "name": "Config File",
+                    "description": "Configuration File for Driverless AI",
+                    "type": "FILE",
+                    "filter": "*.toml",
+                    "positional": true,
+                    "required": false
+                }
+            }
         }
     },
     "image": {

--- a/NAE/help.html
+++ b/NAE/help.html
@@ -1,0 +1,10 @@
+<h1>DRIVERLESS AI SERVER</h1>
+<p> You can connect to the Driverless AI GUI at:
+<br><a href="https://%PUBLICADDR%:12345/">https://%PUBLICADDR%:12345/</a>.
+<br>If this is the first time you are accessing this machine, you will be prompted for a license after entering a username and password
+<br>
+<br>Documentation for Driverless AI can be found <a href="http://docs.h2o.ai/driverless-ai/latest-stable/docs/userguide/index.html">here</a>
+<br>
+<br>If you need a license contact sales at:
+<br><a href="sales@h2o.ai">sales@h2o.ai</a>
+</p>

--- a/NAE/url.txt
+++ b/NAE/url.txt
@@ -1,0 +1,1 @@
+https://%PUBLICADDR%:12345/

--- a/run-dai-nimbix.sh
+++ b/run-dai-nimbix.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
-sudo nvidia-smi -pm 1
+set -e
+set -x
+
+export DRIVERLESS_AI_CONFIG_FILE_PATH="/opt/h2oai/dai"
+echo "$DRIVERLESS_AI_CONFIG_FILE_PATH"
+
+if [ -z "$5" ]
+then
+  echo "No Configuration File Provided"
+else
+  echo "Making Configuration File Available for DAI"
+  CONFIG_FILE="$5"
+  cp $CONFIG_FILE "$DRIVERLESS_AI_CONFIG_FILE_PATH/config.toml"
+fi
+
+echo "Starting Driverless AI"
+
+if [ $4 -gt 0 ]
+then
+  sudo nvidia-smi -pm 1
+else
+  echo "No GPUs Available, CPU Only"
+fi
+
 /opt/h2oai/dai/run-h2oai.sh
-tail -f /opt/h2oai/dai/log/h2oai.out 
+tail -f /opt/h2oai/dai/log/h2oai.out


### PR DESCRIPTION
Config.toml file can now be accepted into driverless ai.

Add to Jarvice vault via sftp and then select as optional argument when launching nimbix deployment